### PR TITLE
Fix Tally extended proposal alert handling

### DIFF
--- a/docs/tally_integration.md
+++ b/docs/tally_integration.md
@@ -51,6 +51,8 @@ The monitor system manages proposal state and alert delivery:
    - Detected when a proposal's state changes (e.g., to extended)
    - Sends alert as a thread reply
    - Updates tracking state
+   - **Extended Proposals**: When a proposal transitions from "active" to "extended", it sends a "proposal_update" alert instead of "proposal_ended"
+   - **Extended to Final**: When a proposal transitions from "extended" to a final state (succeeded, defeated, etc.), it sends a "proposal_ended" alert and removes from tracking
 
 3. **Ended Proposals**:
    - Detected when a proposal's state changes to final state (succeeded, defeated, etc.)

--- a/src/monitor/monitor_tally.py
+++ b/src/monitor/monitor_tally.py
@@ -135,8 +135,26 @@ async def process_tally_proposal_alert(
         # Determine alert type
         if not previous_status:
             alert_type = "proposal_active"
-        elif previous_status == "active" and proposal.status != "active":
-            alert_type = "proposal_ended"
+        elif previous_status == "active":
+            if proposal.status == "extended":
+                alert_type = "proposal_update"  # Handle extended as an update
+            elif proposal.status != "active":
+                alert_type = "proposal_ended"
+            else:
+                # Skip other status changes
+                return
+        elif previous_status == "extended":
+            # Handle transitions from extended to final states
+            final_statuses = {
+                "succeeded", "archived", "canceled", "callexecuted",
+                "defeated", "executed", "expired", "queued",
+                "pendingexecution", "crosschainexecuted"
+            }
+            if proposal.status.lower() in final_statuses:
+                alert_type = "proposal_ended"
+            else:
+                # Skip other status changes from extended
+                return
         else:
             # Skip other status changes
             return


### PR DESCRIPTION
- Fix incorrect 'proposal_ended' alerts for proposals transitioning from active to extended
- Add proper handling for transitions from extended to final states
- Update documentation to clarify extended proposal behavior
- Ensure extended proposals send 'proposal_update' alerts instead of 'proposal_ended'
- Maintain thread context for all proposal status changes